### PR TITLE
Update jquery.stickyNavbar.js

### DIFF
--- a/jquery.stickyNavbar.js
+++ b/jquery.stickyNavbar.js
@@ -77,7 +77,7 @@
         if (options.selector === 'li') {
           href = $(this).children('a').attr('href');
         } else {
-          href = $(this).attr('href');
+          href = $(this).attr('href') || '/';
         }
 
         // let normal links in navigation redirect to location


### PR DESCRIPTION
If you click on a drop-down menu item that does not have a link href property, set as root